### PR TITLE
Fix build errors on Mac OS

### DIFF
--- a/include/dos/routine.h
+++ b/include/dos/routine.h
@@ -29,7 +29,7 @@ struct Routine {
     Routine(const std::string &name, const Block &extents) : name(name), extents(extents), near(true) {}
     Address entrypoint() const { return extents.begin; }
     // for sorting purposes
-    bool operator<(const Routine &other) { return entrypoint() < other.entrypoint(); }
+    bool operator<(const Routine &other) const { return entrypoint() < other.entrypoint(); }
     bool isValid() const { return extents.isValid(); }
     bool isUnchunked() const { return reachable.size() == 1 && unreachable.empty() && reachable.front() == extents; }
     bool isReachable(const Block &b) const;

--- a/include/dos/types.h
+++ b/include/dos/types.h
@@ -4,6 +4,8 @@
 #include <cstdint>
 #include <cstdlib>
 
+#include <unistd.h> // for ssize_t
+
 using Byte   = uint8_t;
 using SByte  = int8_t;
 using Word   = uint16_t;

--- a/tools/addrtool.cpp
+++ b/tools/addrtool.cpp
@@ -2,6 +2,7 @@
 #include <string>
 #include <regex>
 #include <iomanip>
+#include <sstream>
 #include "dos/memory.h"
 #include "dos/types.h"
 


### PR DESCRIPTION
Hi, I recently tried building this on Mac OS (using Apple Clang 13.0.0), and noticed a few build errors - mostly due to missing includes, and one method that wasn't marked as `const`. This PR fixes these errors.