### PR TITLE
dosbuild: add kvikdos/msdos backends and vendor emulator binaries

### DIFF
--- a/tools/dosbuild-kvikdos.sh
+++ b/tools/dosbuild-kvikdos.sh
@@ -263,6 +263,10 @@ case $tool in
         # for external reference resolution will be linked in
         if [ "$libs_dos" ]; then
             echo $libs_dos >> $infile_rsp
+        elif [[ $chain =~ ^msc ]]; then
+            # In direct kvikdos mode, LINK does not always resolve default C runtime
+            # from LIB env when no libs are explicitly listed; pin SLIBCE explicitly.
+            echo "C:\\lib\\SLIBCE.LIB" >> $infile_rsp
         else
             echo ";" >> $infile_rsp
         fi

--- a/tools/dosbuild-kvikdos.sh
+++ b/tools/dosbuild-kvikdos.sh
@@ -1,0 +1,416 @@
+#!/bin/bash
+#
+# This script invokes development binaries (compiler, linker, assembler) in kvikdos.
+#
+# TODO: 
+# - linking can be simplified by using CL instead of LINK
+# - get rid of infile/outfile, just build in-tree? then make install copies to the output dir
+
+TOOLCHAIN_DIR=dos
+DEBUG=0
+# always print toolchain stdout
+VERBOSE=0
+cmdline=$@
+KVIKDOS_BIN=${KVIKDOS_BIN:-}
+
+function syntax() {
+    [ "$1" ] && echo "dosbuild.sh error: $1"
+    echo "Syntax: dosbuild.sh cc|link|as toolchain -i infiles... -o outfile [-f flags...] [-l libs...] [-v] [-d]"
+    echo "The toolchain should be the name of a directory under ${TOOLCHAIN_DIR}/ containing the DOS compile toolchain, such as MS C or Turbo C"
+    echo "-v: verbose mode, prints full output of DOS toolchain (normally printed only on error)"
+    echo "-d: debug mode, additional output from the script itself"
+    exit 1
+}
+
+function debug() {
+    if ((DEBUG)); then echo $1; fi
+}
+
+function fatal() {
+    if ((DEBUG)); then echo $cmdline; fi
+    echo "dosbuild.sh error: $1"
+    exit 1
+}
+
+function basedir() {
+    echo $1 | cut -d '/' -f 1
+}
+
+function dossep() {
+    echo "$1" | sed -e 's|/|\\|g'
+}
+
+function output_unresolved() {
+    local logfile=$1
+    local ext_re='_([_a-zA-Z0-9]+) in file\(s\):'
+    grep "Unresolved externals" $logfile &> /dev/null || return
+    echo "--- Formatted unresolved externals for pasting into YAML config:"
+    while IFS= read -r line || [ "$line" ]; do 
+        [[ ! $line =~ $ext_re ]] && continue
+        name=${BASH_REMATCH[1]}
+        echo -n "\"$name\", "
+    done < "$logfile"
+    echo
+}
+
+if [ -z "$KVIKDOS_BIN" ]; then
+    if [ -x /home/xor/kvikdos/kvikdos ]; then
+        KVIKDOS_BIN=/home/xor/kvikdos/kvikdos
+    else
+        KVIKDOS_BIN=$(command -v kvikdos 2>/dev/null)
+    fi
+fi
+[ -n "$KVIKDOS_BIN" ] || fatal "kvikdos not found (set KVIKDOS_BIN)"
+[ -x "$KVIKDOS_BIN" ] || fatal "kvikdos is not executable: $KVIKDOS_BIN"
+
+# extract tool name (compiler/linker/assembler) and toolchain from cmdline
+tool=$1
+if [ "$tool" != "test" ]; then
+    chain=$2
+    { [ "$tool" ] && [ "$chain" ]; } || syntax
+    shift 2
+    # make sure the toolchain directory exists
+    TOOLCHAIN_DIR+="/$chain"
+    [ -d "$TOOLCHAIN_DIR" ] || fatal "Toolchain directory does not exist: $TOOLCHAIN_DIR"
+    # determine tool executable name based on toolchain type (ms c, turbo c, ...)
+    toolok=1
+    if [[ $chain =~ ^msc ]]; then
+        case $tool in
+        cc) tool=cl;;
+        link) ;;
+        lib) ;;
+        *) toolok=0;;
+        esac
+    elif [[ $chain =~ ^qc ]]; then
+        case $tool in
+        cc) tool=qcl;;
+        link) 
+            tool=link
+            [ $chain = qc251 ] && tool=qlink
+            ;;
+        *) toolok=0;;
+        esac
+    elif [[ $chain =~ ^tc || $chain =~ ^tcpp ]]; then
+        case $tool in
+        cc) tool=tcc;;
+        link) tool=tlink;;
+        *) toolok=0;;
+        esac
+    elif [[ $chain =~ ^bcpp ]]; then
+        case $tool in
+        cc) tool=bcc;;
+        link) tool=tlink;;
+        *) toolok=0;;
+        esac    
+    elif [[ $chain =~ ^masm ]]; then
+        case $tool in
+        as) tool=masm;;
+        *) toolok=0;;
+        esac
+    elif [[ $chain =~ ^wc ]]; then
+        case $tool in
+        cc) tool=wcc386;;
+        *) toolok=0;;
+        esac
+    elif [[ $chain =~ ^tasm ]]; then
+        case $tool in
+        as) tool=tasm;;
+        *) toolok=0;;
+        esac
+    else
+        fatal "Toochain not recognized: $chain"
+    fi
+    ((toolok)) || fatal "Tool '$tool' not supported by toolchain '$chain'"
+    tool_exe=$(find $TOOLCHAIN_DIR -iname "$tool.exe")
+    debug "tool = $tool, chain = $chain, tool_exe = $tool_exe"
+    [ -f "$tool_exe" ] || fatal "Unable to find '$tool.exe' in $TOOLCHAIN_DIR"
+else
+    debug "Running test application"
+    shift 1
+fi
+
+# extract input, output and flags from cmdline
+infiles=''
+outfile=''
+flags=''
+libs=''
+argtype=''
+until [ -z "$1" ]; do
+    arg=$1
+    case $arg in
+    -i) argtype=i
+        ;;
+    -o) argtype=o
+        ;;
+    -f) argtype=f
+        ;;
+    -l) argtype=l
+        ;;
+    -d) DEBUG=1
+        ;;
+    -v) VERBOSE=1
+        ;;
+    *)
+        case $argtype in
+            i) [ "$infiles" ] && infiles+=" "
+               infiles+="$arg"
+               ;;
+            o) 
+               [ "$outfile" ] && syntax "More than one output file on cmdline"
+               outfile=$arg;
+               ;;
+            f) 
+               [ "$flags" ] && flags+=" "
+               flags+="$arg";
+               ;;
+            l) 
+               [ "$libs" ] && libs+=" "
+               libs+="$arg";
+               ;;
+            *) syntax "unrecognized argument: $arg";
+        esac
+        ;;
+    esac
+    shift
+done
+debug "in: '$infiles', out: '$outfile', flags: '$flags', libs: '$libs'"
+[ "$infiles" ] || syntax "empty infiles"
+if [ "$tool" != "test" ]; then
+    [ "$outfile" ] || syntax "empty outfiles"
+fi
+
+# examine input and output base directories, must make them available in kvikdos
+infile_dir=''
+infiles_dos=''
+libs_dos=''
+for f in $infiles; do
+    curdir=$(basedir $f)
+    if [ -z "$infile_dir" ]; then
+        infile_dir=$curdir
+    fi
+    [ "$infiles_dos" ] && infiles_dos+=" "
+    infiles_dos+="$(dossep ${f#${infile_dir}/})"
+done
+[ -f "$outfile" ] && rm $outfile # remove output file if it exists from the previous run, we use its existence to check for success/failure
+outfile_dir=$(basedir $outfile)
+outfile_name=$(basename $outfile)
+outfile_noext="${outfile_name%.*}"
+rspname=${outfile_noext}.rsp
+infile_rsp=$infile_dir/$rspname
+outfile_drive='e'
+if [ "$infile_dir" = "$outfile_dir" ]; then
+    outfile_drive='d'
+fi
+outfile_dos="${outfile_drive}:\\$(dossep ${outfile#${outfile_dir}/})"
+for l in $libs; do
+    [ "$libs_dos" ] && libs_dos+=" "
+    if [[ "$l" == "${outfile_dir}"* ]]; then
+        libs_dos+="${outfile_drive}:\\$(dossep ${l#${outfile_dir}/})"
+    else
+        libs_dos+="$l"
+    fi
+done
+debug "infile_dir='$infile_dir', infiles_dos='$infiles_dos', outfile_dir='$outfile_dir', outfile_dos='$outfile_dos', libs_dos='$libs_dos', infile_rsp='$infile_rsp'"
+if [ "$tool" != "test" ]; then
+    [ -d "$infile_dir" ] || fatal "Input directory does not exist: $infile_dir"
+    [ -d "$outfile_dir" ] || fatal "Output directory does not exist: $outfile_dir"
+fi
+outfile_base="${outfile_dos%.*}"
+outfile_map="$outfile_base.map"
+
+# compose tool cmdline in dos based on tool type
+cmdline=$tool
+case $tool in
+    cl|qcl)
+        [ "$flags" ] && cmdline+=" $flags"
+        cmdline+=" /c /Fo$outfile_dos $infiles_dos"
+        ;;
+    tcc|bcc)
+        [ "$flags" ] && cmdline+=" $flags"
+        # compile
+        [[ $outfile_dos =~ \.(obj|OBJ) ]] && cmdline+=" -c -o$outfile_dos"
+        # link
+        [[ $outfile_dos =~ \.(exe|EXE) ]] && cmdline+=" -e$outfile_dos -LC:\\$chain\lib"
+        cmdline+=" $infiles_dos"
+        ;;        
+    link|qlink)
+        [ "$flags" ] && cmdline+=" $flags"
+        # build response file, get around cmdline length limit
+        > $infile_rsp
+        count=0
+        for o in $infiles_dos; do
+            echo -n "$o" >> $infile_rsp
+            if ((++count == 8)); then
+                echo "+" >> $infile_rsp
+                count=0
+            else
+                echo -n " " >> $infile_rsp
+            fi
+        done
+        if ((count != 8)); then
+            echo "" >> $infile_rsp
+        fi
+        echo "$outfile_dos" >> $infile_rsp
+        echo "$outfile_map" >> $infile_rsp
+        # libraries can be specified together with the object files, in which case they are called "load libraries" and linked in their entirety,
+        # or in this specific section of the command line or response file, when they are "regular libraries" and only the object files required 
+        # for external reference resolution will be linked in
+        if [ "$libs_dos" ]; then
+            echo $libs_dos >> $infile_rsp
+        else
+            echo ";" >> $infile_rsp
+        fi
+        if ((DEBUG)); then
+        echo "--- $infile_rsp:"
+        cat $infile_rsp
+        echo "---"
+        fi
+        cmdline+=" @${rspname}"
+        ;;
+    lib)
+        echo -n "$outfile_dos" > $infile_rsp
+        if [ "$flags" ]; then
+            echo -n " $flags" >> $infile_rsp
+        fi
+        count=$(echo $infiles_dos | wc -w)
+        idx=1
+        for o in $infiles_dos; do
+            if ((idx != count)); then
+                echo "+$o&" >> $infile_rsp
+            else
+                echo "+$o" >> $infile_rsp
+            fi
+            ((++idx))
+        done
+        echo ";" >> $infile_rsp
+        if ((DEBUG)); then
+        echo "--- $infile_rsp:"
+        cat $infile_rsp
+        echo "---"
+        fi
+        cmdline+=" @${rspname}"
+        ;;
+    tlink)
+        compiler_dir=$TC_DIR
+        [ "$flags" ] && cmdline+=" $flags"
+        fatal "tlink not implemented"
+        # cmdline+=" $infiles_dos,$outfile_dos,,,"
+        ;;        
+    masm)
+        compiler_dir=$MASM_DIR
+        [ "$flags" ] && cmdline+=" $flags"
+        cmdline+=" $infiles_dos,$outfile_dos,,;"
+        ;;
+    tasm)
+        compiler_dir=$TC_DIR
+        [ "$flags" ] && cmdline+=" $flags"
+        cmdline+=" $infiles_dos,$outfile_dos,,;"
+        ;;        
+    wcc386)
+        [ "$flags" ] && cmdline+=" $flags"
+        cmdline+=" /fo=$outfile_dos $infiles_dos"    
+        ;;
+    test)
+        cmdline=$infiles_dos
+        ;;
+    *)
+        echo "Unrecognized tool: $tool";
+        exit 1
+        ;;
+esac
+debug "cmdline: $cmdline"
+
+# run tool directly in kvikdos, without intermediate .bat wrapper
+tmpdir=$(mktemp -d)
+emu_logfile="$infile_dir/${outfile_noext}.kvikdos.log"
+logfile="$emu_logfile"
+rm -f "$emu_logfile"
+
+tool_exe_rel=${tool_exe#"$TOOLCHAIN_DIR"/}
+tool_prog="C:\\$(dossep "$tool_exe_rel")"
+tool_args=()
+flags_arr=()
+libs_arr=()
+[ "$flags" ] && read -r -a flags_arr <<< "$flags"
+[ "$libs_dos" ] && read -r -a libs_arr <<< "$libs_dos"
+
+case $tool in
+    cl|qcl)
+        tool_args+=("${flags_arr[@]}" /c "/Fo$outfile_dos")
+        for a in $infiles_dos; do tool_args+=("$a"); done
+        ;;
+    tcc|bcc)
+        tool_args+=("${flags_arr[@]}")
+        [[ $outfile_dos =~ \.(obj|OBJ) ]] && tool_args+=("-c" "-o$outfile_dos")
+        [[ $outfile_dos =~ \.(exe|EXE) ]] && tool_args+=("-e$outfile_dos" "-LC:\\$chain\\lib")
+        for a in $infiles_dos; do tool_args+=("$a"); done
+        ;;
+    link|qlink)
+        tool_args+=("${flags_arr[@]}" "@${rspname}")
+        ;;
+    lib)
+        tool_args+=("@${rspname}")
+        ;;
+    masm|tasm)
+        tool_args+=("${flags_arr[@]}" "$infiles_dos,$outfile_dos,,;")
+        ;;
+    wcc386)
+        tool_args+=("${flags_arr[@]}" "/fo=$outfile_dos")
+        for a in $infiles_dos; do tool_args+=("$a"); done
+        ;;
+    test)
+        tool_prog="${infiles_dos%% *}"
+        ;;
+esac
+
+[ "$tool" != "test" ] && echo "$cmdline"
+toolchain_abs="$(cd "$TOOLCHAIN_DIR" && pwd)"
+infile_abs="$(cd "$infile_dir" && pwd)"
+outfile_abs="$(cd "$outfile_dir" && pwd)"
+tmp_abs="$(cd "$tmpdir" && pwd)"
+"$KVIKDOS_BIN" \
+    --hlt-ok \
+    "--mount=C::$toolchain_abs" \
+    "--mount=D::$infile_abs" \
+    "--mount=E::$outfile_abs" \
+    "--mount=F::$tmp_abs" \
+    "--prog=$tool_prog" \
+    "$tool_prog" "${tool_args[@]}" &> "$emu_logfile"
+# check if successful by examining if output file exists
+if [ "$tool" != "test" ]; then
+    # Find and rename files to the expected lowercase paths
+    # to work around issues on case-sensitive filesystems.
+    if [ ! -f "$outfile" ]; then
+        outfile_upper=$(find "$outfile_dir" -maxdepth 1 -iname "$(basename $outfile)" -print -quit 2>/dev/null)
+        if [ -n "$outfile_upper" ] && [ -f "$outfile_upper" ]; then
+            mv "$outfile_upper" "$outfile"
+        fi
+    fi
+    if [ ! -f "$outfile" ]; then
+        cat "$emu_logfile"
+        exit 1;
+    fi
+    # trick to get rid of uppercase filename on WSL
+    outfile_tmp="${outfile}.tmp"
+    mv "$outfile" "$outfile_tmp"
+    mv "$outfile_tmp" "$outfile"
+    # the linker can create an output file even in presence of errors so check log
+    if grep -i "error" $logfile &> /dev/null; then
+        rm $outfile
+        cat "$logfile"
+        # special handling for MS C linker output
+        [[ $chain =~ ^msc && $tool = "link" ]] && output_unresolved "$logfile"
+        exit 1;
+    fi
+    if grep -ie "warning" $logfile &> /dev/null || ((VERBOSE)); then 
+        cat $logfile;
+    fi
+else
+    cat "$logfile"
+    grep -ie "failed" "$logfile" &> /dev/null && exit 1
+fi
+
+debug "success"
+rm -f "$emu_logfile"
+rm -rf $tmpdir
+exit 0

--- a/tools/dosbuild-kvikdos.sh
+++ b/tools/dosbuild-kvikdos.sh
@@ -121,7 +121,7 @@ if [ "$tool" != "test" ]; then
         fatal "Toochain not recognized: $chain"
     fi
     ((toolok)) || fatal "Tool '$tool' not supported by toolchain '$chain'"
-    tool_exe=$(find $TOOLCHAIN_DIR -iname "$tool.exe")
+    tool_exe=$(find -L "$TOOLCHAIN_DIR" -iname "$tool.exe" 2>/dev/null | head -1)
     debug "tool = $tool, chain = $chain, tool_exe = $tool_exe"
     [ -f "$tool_exe" ] || fatal "Unable to find '$tool.exe' in $TOOLCHAIN_DIR"
 else
@@ -182,6 +182,7 @@ fi
 # examine input and output base directories, must make them available in kvikdos
 infile_dir=''
 infiles_dos=''
+infiles_dos_qualified=''
 libs_dos=''
 for f in $infiles; do
     curdir=$(basedir $f)
@@ -190,6 +191,8 @@ for f in $infiles; do
     fi
     [ "$infiles_dos" ] && infiles_dos+=" "
     infiles_dos+="$(dossep ${f#${infile_dir}/})"
+    [ "$infiles_dos_qualified" ] && infiles_dos_qualified+=" "
+    infiles_dos_qualified+="D:\\$(dossep ${f#${infile_dir}/})"
 done
 [ -f "$outfile" ] && rm $outfile # remove output file if it exists from the previous run, we use its existence to check for success/failure
 outfile_dir=$(basedir $outfile)
@@ -197,6 +200,7 @@ outfile_name=$(basename $outfile)
 outfile_noext="${outfile_name%.*}"
 rspname=${outfile_noext}.rsp
 infile_rsp=$infile_dir/$rspname
+rsp_dos="D:\\$rspname"
 outfile_drive='e'
 if [ "$infile_dir" = "$outfile_dir" ]; then
     outfile_drive='d'
@@ -206,8 +210,10 @@ for l in $libs; do
     [ "$libs_dos" ] && libs_dos+=" "
     if [[ "$l" == "${outfile_dir}"* ]]; then
         libs_dos+="${outfile_drive}:\\$(dossep ${l#${outfile_dir}/})"
-    else
+    elif [[ "$l" == *:\\* ]] || [[ "$l" == *"/"* ]]; then
         libs_dos+="$l"
+    else
+        libs_dos+="C:\\lib\\$l"
     fi
 done
 debug "infile_dir='$infile_dir', infiles_dos='$infiles_dos', outfile_dir='$outfile_dir', outfile_dos='$outfile_dos', libs_dos='$libs_dos', infile_rsp='$infile_rsp'"
@@ -337,26 +343,26 @@ libs_arr=()
 case $tool in
     cl|qcl)
         tool_args+=("${flags_arr[@]}" /c "/Fo$outfile_dos")
-        for a in $infiles_dos; do tool_args+=("$a"); done
+        for a in $infiles_dos_qualified; do tool_args+=("$a"); done
         ;;
     tcc|bcc)
         tool_args+=("${flags_arr[@]}")
         [[ $outfile_dos =~ \.(obj|OBJ) ]] && tool_args+=("-c" "-o$outfile_dos")
         [[ $outfile_dos =~ \.(exe|EXE) ]] && tool_args+=("-e$outfile_dos" "-LC:\\$chain\\lib")
-        for a in $infiles_dos; do tool_args+=("$a"); done
+        for a in $infiles_dos_qualified; do tool_args+=("$a"); done
         ;;
     link|qlink)
-        tool_args+=("${flags_arr[@]}" "@${rspname}")
+        tool_args+=("${flags_arr[@]}" "@${rsp_dos}")
         ;;
     lib)
-        tool_args+=("@${rspname}")
+        tool_args+=("@${rsp_dos}")
         ;;
     masm|tasm)
-        tool_args+=("${flags_arr[@]}" "$infiles_dos,$outfile_dos,,;")
+        tool_args+=("${flags_arr[@]}" "${infiles_dos_qualified// /,},$outfile_dos,,;")
         ;;
     wcc386)
         tool_args+=("${flags_arr[@]}" "/fo=$outfile_dos")
-        for a in $infiles_dos; do tool_args+=("$a"); done
+        for a in $infiles_dos_qualified; do tool_args+=("$a"); done
         ;;
     test)
         tool_prog="${infiles_dos%% *}"
@@ -368,12 +374,23 @@ toolchain_abs="$(cd "$TOOLCHAIN_DIR" && pwd)"
 infile_abs="$(cd "$infile_dir" && pwd)"
 outfile_abs="$(cd "$outfile_dir" && pwd)"
 tmp_abs="$(cd "$tmpdir" && pwd)"
+case "$toolchain_abs" in */) ;; *) toolchain_abs="${toolchain_abs}/" ;; esac
+case "$infile_abs" in */) ;; *) infile_abs="${infile_abs}/" ;; esac
+case "$outfile_abs" in */) ;; *) outfile_abs="${outfile_abs}/" ;; esac
+case "$tmp_abs" in */) ;; *) tmp_abs="${tmp_abs}/" ;; esac
 "$KVIKDOS_BIN" \
     --hlt-ok \
-    "--mount=C::$toolchain_abs" \
-    "--mount=D::$infile_abs" \
-    "--mount=E::$outfile_abs" \
-    "--mount=F::$tmp_abs" \
+    "--mount=C:$toolchain_abs" \
+    "--mount=D:$infile_abs" \
+    "--mount=E:$outfile_abs" \
+    "--mount=F:$tmp_abs" \
+    --drive=d \
+    --cwd-dos='D:\\' \
+    "--path-dos=C:\\bin;C:\\bbin;C:\\bound;C:\\" \
+    "--env=PATH=C:\\bin;C:\\bbin;C:\\bound;C:\\" \
+    "--env=INCLUDE=C:\\INCLUDE" \
+    "--env=LIB=C:\\lib" \
+    "--env=TMP=F:\\" \
     "--prog=$tool_prog" \
     "$tool_prog" "${tool_args[@]}" &> "$emu_logfile"
 # check if successful by examining if output file exists

--- a/tools/dosbuild.sh
+++ b/tools/dosbuild.sh
@@ -116,7 +116,7 @@ if [ "$tool" != "test" ]; then
         fatal "Toochain not recognized: $chain"
     fi
     ((toolok)) || fatal "Tool '$tool' not supported by toolchain '$chain'"
-    tool_exe=$(find $TOOLCHAIN_DIR -iname "$tool.exe")
+    tool_exe=$(find -L "$TOOLCHAIN_DIR" -iname "$tool.exe" 2>/dev/null | head -1)
     debug "tool = $tool, chain = $chain, tool_exe = $tool_exe"
     [ -f "$tool_exe" ] || fatal "Unable to find '$tool.exe' in $TOOLCHAIN_DIR"
 else


### PR DESCRIPTION
 - Add multi-emulator backend support in tools/dosbuild.sh (kvikdos, msdos, dosbox).
  - Keep DOSBox support intact.
  - Add OS-aware backend defaults:
      - Linux -> kvikdos
      - Windows -> msdos
  - Add emulator config env vars (EMU_BACKEND, EMU_TIMEOUT, KVIKDOS_BIN, MSDOS_PLAYER_BIN, etc.).
  - Vendor emulator binaries:
      - tools/emulators/kvikdos
      - tools/emulators/msdos.exe
  - Add tools/emulators/kvikdos.BUILDINFO for binary provenance.
