### PR TITLE
support for after symbols

### DIFF
--- a/bin/egame.map
+++ b/bin/egame.map
@@ -6,7 +6,7 @@ Size 28f70
 # Discovered segments, one per line, syntax is "SegmentName Type(CODE/DATA/STACK) Address"
 #
 Code1 CODE 0000
-Data3 DATA 0040
+Data3 DATA 0040 default
 Data2 DATA 009d
 Code4 CODE 0f88
 Code2 CODE 11a7
@@ -29,13 +29,13 @@ Data1 DATA 228b
 #
 start: Code1 NEAR 0000-000f R0000-000f
 routine_7: Code1 NEAR 0010-0146 R0010-0146
-routine_22: Code1 NEAR 0147-0210 R0147-0210
+routine_22: Code1 NEAR 0147-0210[Data2] R0147-0210
 routine_23: Code1 NEAR 0211-0293 R0211-0293
 routine_6: Code1 NEAR 0294-0296 R0294-0296
 routine_5: Code1 NEAR 0297-0299 R0297-0299
 routine_17: Code1 NEAR 029a-02e1 R029a-02e1
 routine_37: Code1 NEAR 02e2-0333 R02e2-0333
-routine_292: Code1 NEAR 0334-0685 R0334-03ff R0400-0685
+routine_292: Code1 NEAR 0334-0685 R0334-03ff R0400-0685[Data2]
 routine_14: Code1 NEAR 0688-06e0 R0688-069a U069b-069f R06a0-06e0
 routine_109: Code1 NEAR 0720-14e7 R0720-09cf R09d0-14e7
 routine_181: Code1 NEAR 14e8-14fb R14e8-14fb

--- a/bin/egame.map
+++ b/bin/egame.map
@@ -6,12 +6,12 @@ Size 28f70
 # Discovered segments, one per line, syntax is "SegmentName Type(CODE/DATA/STACK) Address"
 #
 Code1 CODE 0000
-Data3 DATA 0040 default
+Data3 DATA 0040
 Data2 DATA 009d
 Code4 CODE 0f88
 Code2 CODE 11a7
 Code3 CODE 1274
-Data1 DATA 228b
+Data1 DATA 228b default
 #
 # Discovered routines, one per line, syntax is "RoutineName: Segment Type(NEAR/FAR) Extents [R/U]Block1 [R/U]Block2... [annotation1] [annotation2]..."
 # The routine extents is the largest continuous block of instructions attributed to this routine and originating

--- a/include/dos/address.h
+++ b/include/dos/address.h
@@ -75,6 +75,7 @@ inline std::string operator+(const std::string &str, const Address &arg) { retur
 // An address range, both ends inclusive
 struct Block {
     Address begin, end;
+    std::string segName;
 
     Block(const Address &begin, const Address &end) : begin(begin), end(end) {}
     Block(const Address &begin) : Block(begin, begin) {}
@@ -117,11 +118,12 @@ struct Segment {
         SEG_STACK
     } type;
     Word address;
+    bool isDefault;
 
     static std::smatch stringMatch(const std::string &str);
     static std::string typeString(const Type t);
 
-    Segment(const std::string &name, Type type, Word address) : name(name), type(type), address(address) {}
+    Segment(const std::string &name, Type type, Word address) : name(name), type(type), address(address), isDefault(false) {}
     Segment(const std::smatch &match);
     Segment(const std::string &str) : Segment(stringMatch(str)) {}
     Segment() : Segment("", SEG_NONE, 0) {}

--- a/include/dos/codemap.h
+++ b/include/dos/codemap.h
@@ -13,11 +13,13 @@
 struct Variable {
     std::string name;
     Address addr;
+    Offset off;
     bool external, bss;
     static std::smatch stringMatch(const std::string &str);
-    Variable() {}
-    Variable(const std::string &name, const Address &addr) : name(name), addr(addr), external(false), bss(false) {}
+    Variable() : off(0) {}
+    Variable(const std::string &name, const Address &addr) : name(name), addr(addr), off(0), external(false), bss(false) {}
     std::string toString(const bool brief = true) const;
+    std::string symbol() const;
     bool operator<(const Variable &other) const { return addr < other.addr; }
 };
 
@@ -73,8 +75,7 @@ public:
     std::vector<Block> getUnclaimed() const { return unclaimed; }
     Variable getVariable(const Size idx) const { return vars.at(idx); }
     Variable getVariable(const std::string &name) const;
-    Variable getVariable(const Address &addr) const;
-    std::vector<Variable> getVariables(const Word &offset) const;
+    Variable getVariable(const Address &addr, const bool before = false) const;
     Routine findByEntrypoint(const Address &ep) const;
     Block findCollision(const Block &b) const;
     bool empty() const { return routines.empty(); }
@@ -89,6 +90,7 @@ public:
     Segment findSegment(const Word addr) const;
     Segment findSegment(const std::string &name) const;
     Segment findSegment(const Offset off, const bool past = false) const;
+    Segment defaultSegment() const;
     void setSegments(const std::vector<Segment> &seg);
     
 private:

--- a/include/dos/codemap.h
+++ b/include/dos/codemap.h
@@ -13,7 +13,7 @@
 struct Variable {
     std::string name;
     Address addr;
-    Offset off;
+    Offset off; // optional offset from the exact variable location, zero by default, used to enable matching memory location ranges to variables
     bool external, bss;
     static std::smatch stringMatch(const std::string &str);
     Variable() : off(0) {}

--- a/src/address.cpp
+++ b/src/address.cpp
@@ -143,6 +143,7 @@ std::string Block::toString(const bool linear, const bool showSize, const bool i
     if (!linear) str << begin.toString(!includeLinear) << "-" << end.toString(!includeLinear);
     else str << hexVal(begin.toLinear(), false, OFFSET_STRLEN) << "-" << hexVal(end.toLinear(), false, OFFSET_STRLEN);
     if (showSize) str << "[" << hex << setw(OFFSET_STRLEN) << setfill('0') << size() << "]";
+    if (!segName.empty()) str << "[" << segName << "]";
     return str.str();
 }
 
@@ -245,7 +246,7 @@ std::ostream& operator<<(std::ostream &os, const Block &arg) {
     return os << arg.toString();
 }
 
-Segment::Segment(const std::smatch &match) {
+Segment::Segment(const std::smatch &match) : isDefault(false) {
     if (match.empty()) throw ArgError("Segment string mismatch");
     name = match.str(1);
     address = stoi(match.str(3), nullptr, 16);
@@ -254,10 +255,12 @@ Segment::Segment(const std::smatch &match) {
     else if (segtype == "DATA") type = SEG_DATA;
     else if (segtype == "STACK") type = SEG_STACK;
     else throw ArgError("Invalid segment type string: " + segtype);
+    const string trailing = match.str(4);
+    if (trailing == "default") isDefault = true;
 }
 
 std::smatch Segment::stringMatch(const std::string &str) {
-    static const regex SEG_RE{"^([$_a-zA-Z0-9]+) (CODE|DATA|STACK) ([0-9a-fA-F]{1,4})"};
+    static const regex SEG_RE{"^([$_a-zA-Z0-9]+)\\s(CODE|DATA|STACK)\\s([0-9a-fA-F]{1,4})\\s?(.*)?"};
     smatch match;
     regex_match(str, match, SEG_RE);
     return match;
@@ -283,5 +286,6 @@ std::string Segment::toString() const {
     default:        str << "??? "; break; 
     }
     str << hexVal(address, false);
+    if (isDefault) str << " default";
     return str.str();
 }

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -941,9 +941,15 @@ string Analyzer::symbolName(const Executable &exe, const Instruction &i) const {
     // byte offsets implausible?
     else if (operandIsMemWithWordOffset(i.op1.type) || operandIsMemWithWordOffset(i.op2.type)) {
         const Word offset = operandIsMemWithWordOffset(i.op1.type) ? i.op1.wordValue() : i.op2.wordValue();
-        string ret;
-        for (const Variable &v : exe.map().getVariables(offset)) ret += (ret.empty() ? "" : "|") + v.name;
-        return ret;
+        // find data segment of current block; either a custom override, or the executable's default segment
+        Segment dataSeg;
+        if (!compareBlock.segName.empty()) dataSeg = exe.map().findSegment(compareBlock.segName);
+        else dataSeg = exe.map().defaultSegment();
+        if (dataSeg.type != Segment::SEG_DATA) throw AnalysisError("Unable to find data segment of block " + compareBlock.toString());
+        Address varAddr{dataSeg.address, offset};
+        Variable v = exe.map().getVariable(varAddr, true);
+        if (!v.addr.isValid()) throw AnalysisError("Unable to find variable for address " + varAddr.toString());
+        return v.symbol();
     }
     return {};
 }

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -938,18 +938,36 @@ string Analyzer::symbolName(const Executable &exe, const Instruction &i) const {
         const Routine r = exe.map().findByEntrypoint(i.op1.farAddr());
         return r.name;
     }
-    // byte offsets implausible?
+    // TODO: byte offsets implausible?
     else if (operandIsMemWithWordOffset(i.op1.type) || operandIsMemWithWordOffset(i.op2.type)) {
         const Word offset = operandIsMemWithWordOffset(i.op1.type) ? i.op1.wordValue() : i.op2.wordValue();
         // find data segment of current block; either a custom override, or the executable's default segment
-        Segment dataSeg;
-        if (!compareBlock.segName.empty()) dataSeg = exe.map().findSegment(compareBlock.segName);
-        else dataSeg = exe.map().defaultSegment();
-        if (dataSeg.type != Segment::SEG_DATA) throw AnalysisError("Unable to find data segment of block " + compareBlock.toString());
-        Address varAddr{dataSeg.address, offset};
+        Segment varSeg;
+        // handle segment override prefixes
+        switch (i.prefix) {
+        case PRF_SEG_CS:
+            // cs override, can determine from instruction address
+            varSeg = exe.map().findSegment(i.addr.segment);
+            break;
+        case PRF_SEG_ES:
+        case PRF_SEG_SS:
+            // values of es and ss are unknown, unable to determine symbol name
+            return {};
+        case PRF_NONE:
+        case PRF_SEG_DS:
+        default:
+            // no seg override or ds, search for data segment
+            varSeg = !compareBlock.segName.empty() ? exe.map().findSegment(compareBlock.segName) : exe.map().defaultSegment();
+            break;
+        }
+        if (varSeg.type == Segment::SEG_NONE) {
+            verbose("Unable to find segment for memory offset " + hexVal(offset) + ", instruction address " + i.addr.toString() + ", compare block: " + compareBlock.toString());
+            return {};
+        }
+        Address varAddr{varSeg.address, offset};
         Variable v = exe.map().getVariable(varAddr, true);
-        if (!v.addr.isValid()) throw AnalysisError("Unable to find variable for address " + varAddr.toString());
-        return v.symbol();
+        if (v.addr.isValid()) return v.symbol();
+        else debug("Unable to find variable for address " + varAddr.toString());
     }
     return {};
 }

--- a/src/codemap.cpp
+++ b/src/codemap.cpp
@@ -27,6 +27,11 @@ std::string Variable::toString(const bool brief) const {
     return oss.str();
 }
 
+std::string Variable::symbol() const {
+    if (off == 0) return name;
+    else return name + "+" + hexVal(off);
+}
+
 void CodeMap::blocksFromQueue(const ScanQueue &sq, const bool unclaimedOnly) {
     const Offset startOffset = SEG_TO_OFFSET(loadSegment);
     Offset endOffset = startOffset + mapSize;
@@ -172,18 +177,22 @@ Variable CodeMap::getVariable(const std::string &name) const {
     return Variable{"", {}};
 }
 
-Variable CodeMap::getVariable(const Address &addr) const {
+Variable CodeMap::getVariable(const Address &addr, const bool before) const {
+    // try perfect match on the variable address first
     auto it = std::find_if(vars.begin(), vars.end(), [&](const Variable &v){
         return v.addr == addr;
     });
     if (it != vars.end()) return *it;
+    // find the closest variable whose address is before the argument
+    if (before) {
+        Variable ret;
+        auto it = std::find_if(vars.rbegin(), vars.rend(), [&](const Variable &v){
+            return v.addr <= addr;
+        });
+        if (it != vars.rend()) return *it;
+    }
+    // nothing found
     return Variable{"", {}};
-}
-
-vector<Variable> CodeMap::getVariables(const Word &offset) const {
-    vector<Variable> ret;
-    for (const auto &v : vars) if (v.addr.offset == offset) ret.push_back(v);
-    return ret;
 }
 
 Routine CodeMap::findByEntrypoint(const Address &ep) const {
@@ -585,11 +594,22 @@ Segment CodeMap::findSegment(const Offset off, const bool past) const {
     return ret;
 }
 
+Segment CodeMap::defaultSegment() const {
+    Segment ret;
+    for (const auto &s : segments) {
+        // find segment explicitly marked as default
+        if (s.isDefault) return s;
+        // find the first data segment otherwise
+        if (ret.type == Segment::SEG_NONE && s.type == Segment::SEG_DATA) ret = s;
+    }
+    return ret;
+}
+
 enum BlockType { BLOCK_NONE, BLOCK_EXTENTS, BLOCK_REACHABLE, BLOCK_UNREACHABLE };
 
 void CodeMap::loadFromMapFile(const std::string &path, const Word reloc) {
     static const regex 
-        RANGE_RE{"([0-9a-fA-F]{1,4})-([0-9a-fA-F]{1,4})"},
+        RANGE_RE{"([0-9a-fA-F]{1,4})-([0-9a-fA-F]{1,4})(?:\\[([a-zA-Z0-9]+)\\])?"},
         SIZE_RE{"Size\\s+([0-9a-fA-F]+)"};
     debug("Loading code map from "s + path + ", relocating to " + hexVal(reloc));
     ifstream mapFile{path};
@@ -680,6 +700,9 @@ void CodeMap::loadFromMapFile(const std::string &path, const Word reloc) {
             if (!regex_match(token, match, RANGE_RE)) throw ParseError("Line " + to_string(lineno) + ": invalid routine block '" + token + "'");
             Block block{Address{rseg.address, static_cast<Word>(stoi(match.str(1), nullptr, 16))}, 
                         Address{rseg.address, static_cast<Word>(stoi(match.str(2), nullptr, 16))}};
+            const string segStr = match.str(3);
+            if (!segStr.empty())
+                block.segName = segStr;
             // check block for collisions against rest of routines already in the map as well as the currently built routine
             Routine colideRoutine = colidesBlock(block);
             if (!colideRoutine.isValid() && r.colides(block, false)) 

--- a/src/codemap.cpp
+++ b/src/codemap.cpp
@@ -185,11 +185,15 @@ Variable CodeMap::getVariable(const Address &addr, const bool before) const {
     if (it != vars.end()) return *it;
     // find the closest variable whose address is before the argument
     if (before) {
-        Variable ret;
         auto it = std::find_if(vars.rbegin(), vars.rend(), [&](const Variable &v){
             return v.addr <= addr;
         });
-        if (it != vars.rend()) return *it;
+        if (it != vars.rend()) {
+            Variable ret(*it);
+            assert(ret.addr.offset <= addr.offset);
+            ret.off = addr.offset - ret.addr.offset;
+            return ret;
+        }
     }
     // nothing found
     return {};

--- a/src/codemap.cpp
+++ b/src/codemap.cpp
@@ -192,7 +192,7 @@ Variable CodeMap::getVariable(const Address &addr, const bool before) const {
         if (it != vars.rend()) return *it;
     }
     // nothing found
-    return Variable{"", {}};
+    return {};
 }
 
 Routine CodeMap::findByEntrypoint(const Address &ep) const {
@@ -383,6 +383,16 @@ void CodeMap::order() {
     // TODO: coalesce adjacent blocks, see routine_35 of hello.exe: 1415-14f7 R1412-1414 R1415-14f7
     for (auto &r : routines) 
         r.recalculateExtents();
+    // before sorting, set default data segment to the first one if not explicitly specified
+    const Segment defSeg = defaultSegment();
+    if (defSeg.type != Segment::SEG_DATA) {
+        for (Segment &s : segments) if (s.type == Segment::SEG_DATA) {
+            s.isDefault = true;
+            warn("Default data segment was not specified, so first segment used: " + s.name);
+            break;
+        }
+        // no data segment found is not an error, if the map is not going to need symbol extraction
+    } 
     sort();
 }
 
@@ -400,19 +410,23 @@ void CodeMap::save(const std::string &path, const Word reloc, const bool overwri
          << "#" << endl
          << "Size " << hexVal(mapSize, false) << endl;
     file << "#" << endl
-         << "# Discovered segments, one per line, syntax is \"SegmentName Type(CODE/DATA/STACK) Address\"" << endl
+         << "# Discovered segments, one per line, syntax is \"SegmentName Type(CODE/DATA/STACK) Address [default]\"" << endl
+         << "# The default data segment is assumed to be used by all routines which don't have data segment overrides." << endl
+         << "# If no default segment is specified, the first one will be used as default." << endl
          << "#" << endl;
     for (auto s: segments) {
         s.address -= reloc;
         file << s.toString() << endl;
     }
     file << "#" << endl
-         << "# Discovered routines, one per line, syntax is \"RoutineName: Segment Type(NEAR/FAR) Extents [R/U]Block1 [R/U]Block2... [annotation1] [annotation2]...\"" << endl
+         << "# Discovered routines, one per line, syntax is \"RoutineName: Segment Type(NEAR/FAR) Extents[DS] [R/U]Block1[DS] [R/U]Block2[DS]... [annotation1] [annotation2]...\"" << endl
          << "# The routine extents is the largest continuous block of instructions attributed to this routine and originating" << endl 
          << "# at the location determined to be the routine's entrypoint." << endl
          << "# Blocks are offset ranges relative to the segment that the routine belongs to, specifying address as belonging to the routine." << endl 
          << "# Blocks starting with R contain code that was determined reachable, U were unreachable but still likely belong to the routine." << endl
          << "# The routine blocks may cover a greater area than the extents if the routine has disconected chunks it jumps into." << endl
+         << "# The extents block and/or the individual routine blocks can have an optional data segment override which is the name" << endl
+         << "# of the data segment assumed to be selected within that block."
          << "# Possible annotation types:" << endl
          << "# ignore - ignore this routine in processing (comparison, signature extraction etc.)" << endl
          << "# complete - this routine was completely reconstructed into C, only influences stat display when printing map" << endl
@@ -596,12 +610,8 @@ Segment CodeMap::findSegment(const Offset off, const bool past) const {
 
 Segment CodeMap::defaultSegment() const {
     Segment ret;
-    for (const auto &s : segments) {
-        // find segment explicitly marked as default
+    for (const auto &s : segments)
         if (s.isDefault) return s;
-        // find the first data segment otherwise
-        if (ret.type == Segment::SEG_NONE && s.type == Segment::SEG_DATA) ret = s;
-    }
     return ret;
 }
 
@@ -746,17 +756,19 @@ void CodeMap::loadFromLinkFile(const std::string &path, const Word reloc) {
     enum {
         LINKMAP_NONE,
         LINKMAP_SEGMENTS,
+        LINKMAP_GROUPS,
         LINKMAP_PUBLICS
     } mode = LINKMAP_NONE;
     static const string 
         HEXVAL_RE_STR{"([0-9A-F]+)"},
         NAME_RE_STR{"([_$0-9A-Za-z]+)"},
         SEGMENTS_RE_STR{"\\s*Start\\s+Stop\\s+Length\\s+Name\\s+Class"},
+        GROUPS_RE_STR{"\\s*Origin\\s+Group"},
         PUBNAME_RE_STR{"\\s*Address\\s+Publics by Name"},
         PUBLVAL_RE_STR{"\\s*Address\\s+Publics by Value"},
         SEGDEF_RE_STR{"\\s*" + HEXVAL_RE_STR + "H\\s+" + HEXVAL_RE_STR + "H\\s+" + HEXVAL_RE_STR + "H\\s+" + NAME_RE_STR + "\\s+" + NAME_RE_STR},
         PUBDEF_RE_STR{"\\s*" + HEXVAL_RE_STR + ":" + HEXVAL_RE_STR + "\\s+" + NAME_RE_STR};
-    static const regex SEGMENTS_RE{SEGMENTS_RE_STR}, PUBNAME_RE{PUBNAME_RE_STR}, PUBVAL_RE{PUBLVAL_RE_STR}, SEGDEF_RE{SEGDEF_RE_STR}, PUBDEF_RE{PUBDEF_RE_STR};
+    static const regex SEGMENTS_RE{SEGMENTS_RE_STR}, GROUPS_RE{GROUPS_RE_STR}, PUBNAME_RE{PUBNAME_RE_STR}, PUBVAL_RE{PUBLVAL_RE_STR}, SEGDEF_RE{SEGDEF_RE_STR}, PUBDEF_RE{PUBDEF_RE_STR};
     vector<string> tokens;
     Size totalSize = 0;
     set<Segment> usedSegs;
@@ -766,6 +778,11 @@ void CodeMap::loadFromLinkFile(const std::string &path, const Word reloc) {
         if (mode != LINKMAP_SEGMENTS && std::regex_match(line, SEGMENTS_RE)) {
             PARSE_DEBUG("Segment definitions starting on line " + to_string(lineno));
             mode = LINKMAP_SEGMENTS; 
+            continue;
+        }
+        else if (mode != LINKMAP_GROUPS && std::regex_match(line, GROUPS_RE)) {
+            PARSE_DEBUG("Group definitions starting on line " + to_string(lineno));
+            mode = LINKMAP_GROUPS; 
             continue;
         }
         // switch into public parsing mode
@@ -792,6 +809,11 @@ void CodeMap::loadFromLinkFile(const std::string &path, const Word reloc) {
             const string
                 name = tokens[3],
                 type = tokens[4];
+            // ignore segments of size zero
+            if (size == 0 || length == 0) {
+                PARSE_DEBUG("Ignoring segment of size zero: " + name);
+                continue;
+            }
             const Word segAddr = OFFSET_TO_SEG(start);
             PARSE_DEBUG("Segment definition on line " + to_string(lineno) + ": start " + hexVal(start) + " (addr " + hexVal(segAddr) + ")" ", stop " + hexVal(stop) + " (size " + hexVal(size) 
                 + "), length " + hexVal(length) + " name '" + name + "', class '" + type + "'");
@@ -809,6 +831,24 @@ void CodeMap::loadFromLinkFile(const std::string &path, const Word reloc) {
                 continue;
             }
             segments.emplace_back(Segment{name, segType, segAddr});
+        }
+        // parse group definition (same syntax as public)
+        else if (mode == LINKMAP_GROUPS && (tokens = extractRegex(PUBDEF_RE, line)).size() == 3) {
+            const Address addr{
+                static_cast<Word>(std::stoi(tokens[0], nullptr, 16)), 
+                static_cast<Word>(std::stoi(tokens[1], nullptr, 16))};
+            string name = tokens[2];
+            if (addr.offset != 0) throw ParseError("Unexpected offset in group address: " + name + "/" + addr.toString());
+            if (name == "DGROUP") {
+                // set default data segment from dgroup address
+                for (Segment &s : segments) if (s.address == addr.segment) {
+                    debug("Set segment " + s.name + " as default based on dgroup address: " + addr.toString());
+                    s.isDefault = true;
+                }
+                // TODO: add segment if it doesn't exist?
+                // TODO: no way to set DS for routine in linkmap, symbols from other segments than default will not be found in routines using a different DS/A
+            }
+
         }
         // parse public definition
         else if (mode == LINKMAP_PUBLICS && (tokens = extractRegex(PUBDEF_RE, line)).size() == 3) {

--- a/test/analysis_test.cpp
+++ b/test/analysis_test.cpp
@@ -213,6 +213,13 @@ TEST_F(AnalysisTest, CodeMapFromLinkMap) {
     ASSERT_EQ(linkMap.segmentCount(), 2);
     ASSERT_EQ(linkMap.routineCount(), 141);
     ASSERT_EQ(linkMap.variableCount(), 250);
+    const string varName = "secondaryHit";
+    const Address varAddr(0x5b7, 0x62a0);
+    Variable v = linkMap.getVariable(varName);
+    ASSERT_EQ(v.addr, varAddr);
+    v = linkMap.getVariable(varAddr);
+    ASSERT_EQ(v.addr, varAddr);
+    ASSERT_EQ(v.name, varName);
 }
 
 TEST_F(AnalysisTest, BigCodeMap) {
@@ -231,6 +238,13 @@ TEST_F(AnalysisTest, BigCodeMap) {
     ASSERT_EQ(s.dataSize, 0x7674);
     ASSERT_EQ(s.dataCodeSize, 0x127);
     ASSERT_EQ(s.dataCodeCount, 59);
+    const Segment ds = rm.defaultSegment();
+    ASSERT_EQ(ds.type, Segment::SEG_DATA);
+    ASSERT_EQ(ds.name, "Data1");
+    const Address vaddr(ds.address, 0x19b8);
+    Variable v = rm.getVariable(vaddr);
+    ASSERT_EQ(v.name, "var_219");
+    ASSERT_EQ(v.addr, vaddr);
 }
 
 TEST_F(AnalysisTest, FindRoutines) {

--- a/test/analysis_test.cpp
+++ b/test/analysis_test.cpp
@@ -214,12 +214,21 @@ TEST_F(AnalysisTest, CodeMapFromLinkMap) {
     ASSERT_EQ(linkMap.routineCount(), 141);
     ASSERT_EQ(linkMap.variableCount(), 250);
     const string varName = "secondaryHit";
-    const Address varAddr(0x5b7, 0x62a0);
+    Address varAddr(0x5b7, 0x62a0);
     Variable v = linkMap.getVariable(varName);
     ASSERT_EQ(v.addr, varAddr);
+    ASSERT_EQ(v.off, 0);
+    ASSERT_EQ(v.symbol(), varName);
     v = linkMap.getVariable(varAddr);
     ASSERT_EQ(v.addr, varAddr);
     ASSERT_EQ(v.name, varName);
+    // variable with offset
+    varAddr = Address(0x5b7, 0x507a + 0x12);
+    v = linkMap.getVariable(varAddr, true);
+    ASSERT_EQ(v.name, "unitTypeTable");
+    ASSERT_EQ(v.addr, Address(0x5b7, 0x507a));
+    ASSERT_EQ(v.off, 0x12);
+    ASSERT_EQ(v.symbol(), "unitTypeTable+0x12");
 }
 
 TEST_F(AnalysisTest, BigCodeMap) {


### PR DESCRIPTION
The tools have problems with figuring out which data segment variables belong to. This enables syntax in the mapfile to set data segments as default for all variables, and to mark routine blocks as having a specific data segment active (default override).

Also implements an optional offset property for variables which will let the tool attribute arbitrary memory locations to the closest variable, instead of expecting the addresses to match perfectly.